### PR TITLE
fix: 修正 Safari 瀏覽器無法使用複製圖片按鈕

### DIFF
--- a/composables/common.ts
+++ b/composables/common.ts
@@ -10,7 +10,7 @@ export const copyToClipboard = (content: string) => {
             });
             const jpegBlob = await jpegImageResponse.blob();
 
-            return await new Promise<Blob>((resolve, reject) => {
+            return new Promise<Blob>((resolve, reject) => {
                 const img = new Image();
                 img.onload = () => {
                     try {
@@ -28,7 +28,7 @@ export const copyToClipboard = (content: string) => {
                         reject(e);
                     }
                 };
-                img.onerror = () => reject;
+                img.onerror = reject;
                 img.src = URL.createObjectURL(jpegBlob);
             });
         };


### PR DESCRIPTION
## 變更描述
修正在 Safari 瀏覽器內使用複製圖片按鈕時會出現 `NotAllowedError` 錯誤

## 變更類型
- [x] Bug 修復
- [ ] 新功能
- [ ] 文檔更新
- [ ] 重構
- [ ] 效能改進
- [ ] 其他

## 測試
- [ ] 我已經運行了現有的測試
- [ ] 我已經為新功能添加了測試
- [ ] 所有測試都通過了

## 截圖（如適用）
WIP, 預計今天晚上提供下列平台測試影片, 提供前先將 PR 標記為 draft
- OSX 26.0.1, Safari 26.0.1 (21622.1.22.11.15)
- OSX 26.0.1, Chrome 141.0.7390.67
- iOS 26.0.1, Safari Builtin 無法確認版本
- iOS 26.0.1, Chrome 141.0.7390.69

## 相關 Issue
Closes #7 