### PR TITLE
Fix deployment instruction in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ MyGO 搜尋器，滿足你上網戰鬥的各種圖戰需求！
 4. 複製環境變數範本並配置
 
     ```bash
-    cp .env.example .env.development
+    cp .env.development.example .env.development
     ```
 
 5. 啟動及部署Nuxt


### PR DESCRIPTION
Fix deployment instruction in README. The original instruction use `.env.example` while the actual file name has been changed to `.env.development.example`.