### PR TITLE
fix: 修正手機版主題與篩選控制列布局

### DIFF
--- a/app/components/Header.vue
+++ b/app/components/Header.vue
@@ -1,11 +1,12 @@
 <template>
-  <div class="relative flex flex-wrap items-center justify-between bg-[--bg-sub] w-full h-30">
-    <div class="mx-8 my-6">
-      <span class="text-2xl font-bold fs-28px text-[--font-default] pb-2">MyGO表情包搜尋器</span><br>
-      <span class="text-sm fs-16px text-[--font-default] pt-2">一輩子跟我一起MyGO嗎</span>
+  <div class="app-header">
+    <div class="app-header__inner">
+      <div class="app-header__copy">
+        <span class="app-header__title">MyGO表情包搜尋器</span>
+        <span class="app-header__subtitle">一輩子跟我一起MyGO嗎</span>
+      </div>
+      <button-color />
     </div>
-    <div class="grow" />
-    <button-color class="mx-8 my-6" />
   </div>
 </template>
 
@@ -14,3 +15,64 @@ defineOptions({
   name: 'AppHeader',
 })
 </script>
+
+<style scoped>
+.app-header {
+  box-sizing: border-box;
+  width: 100%;
+  min-height: 120px;
+  padding: 24px 32px;
+  background: var(--bg-sub);
+}
+
+.app-header__inner {
+  display: flex;
+  width: 100%;
+  min-width: 0;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.app-header__copy {
+  min-width: 0;
+}
+
+.app-header__title,
+.app-header__subtitle {
+  display: block;
+  color: var(--font-default);
+}
+
+.app-header__title {
+  font-size: 28px;
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+.app-header__subtitle {
+  font-size: 16px;
+  line-height: 1.5;
+}
+
+.app-header__subtitle {
+  margin-top: 4px;
+}
+
+@media (max-width: 480px) {
+  .app-header {
+    padding-right: max(20px, env(safe-area-inset-right));
+    padding-left: max(20px, env(safe-area-inset-left));
+  }
+
+  .app-header__inner {
+    gap: 12px;
+  }
+
+  .app-header__title {
+    font-size: clamp(24px, 7vw, 28px);
+    line-height: 1.2;
+    white-space: nowrap;
+  }
+}
+</style>

--- a/app/components/button/color.vue
+++ b/app/components/button/color.vue
@@ -1,14 +1,14 @@
 <template>
-  <div class="flex flex-col relative">
+  <div class="theme-toggle">
     <ClientOnly v-if="!colorMode?.forced">
       <UButton
         :icon="icon"
-        class="size-[32px] flex items-center justify-center p-0 border-[--border] text-[--font-default] bg-[--bg-sub] rounded-md hover:bg-[--bg-hover] transition-colors"
+        class="theme-toggle__button flex items-center justify-center p-0 border-[--border] text-[--font-default] bg-[--bg-sub] rounded-md hover:bg-[--bg-hover] transition-colors"
         :aria-label="`切換主題，目前：${label}`"
         @click="toggle"
       />
       <template #fallback>
-        <div class="size-12" />
+        <div class="theme-toggle__placeholder" />
       </template>
     </ClientOnly>
   </div>
@@ -29,3 +29,23 @@ const icon = computed(() => (isDark.value ? 'i-lucide-moon' : 'i-lucide-sun'))
 
 const label = computed(() => (isDark.value ? '深色' : '淺色'))
 </script>
+
+<style scoped>
+.theme-toggle {
+  display: grid;
+  width: 40px;
+  height: 40px;
+  flex: 0 0 40px;
+  place-items: center;
+}
+
+:deep(.theme-toggle__button),
+.theme-toggle__placeholder {
+  width: 32px;
+  height: 32px;
+}
+
+.theme-toggle__placeholder {
+  display: block;
+}
+</style>

--- a/app/components/button/control.vue
+++ b/app/components/button/control.vue
@@ -3,7 +3,7 @@
     type="button"
     :class="['toolbar-control', { 'toolbar-control--active': active }]"
     :aria-expanded="expanded"
-    :aria-label="label"
+    :aria-label="accessibilityLabel"
     @click="emit('click')"
   >
     <span
@@ -23,7 +23,9 @@
 </template>
 
 <script setup lang="ts">
-withDefaults(defineProps<{
+import { computed } from 'vue'
+
+const props = withDefaults(defineProps<{
   label: string
   active?: boolean
   expanded?: boolean
@@ -34,6 +36,12 @@ withDefaults(defineProps<{
   expanded: false,
   count: 0,
   detail: '',
+})
+
+const accessibilityLabel = computed(() => {
+  if (props.count) return `${props.label}，已套用 ${props.count} 個篩選`
+  if (props.detail) return `${props.label}，目前${props.detail}`
+  return props.label
 })
 
 const emit = defineEmits<{ click: [] }>()

--- a/app/components/button/control.vue
+++ b/app/components/button/control.vue
@@ -3,13 +3,14 @@
     type="button"
     :class="['toolbar-control', { 'toolbar-control--active': active }]"
     :aria-expanded="expanded"
+    :aria-label="label"
     @click="emit('click')"
   >
     <span
       class="control-icon"
       aria-hidden="true"
     ><slot name="icon" /></span>
-    <span>{{ label }}</span>
+    <span class="control-label">{{ label }}</span>
     <span
       v-if="count"
       class="control-badge"
@@ -43,6 +44,7 @@ const emit = defineEmits<{ click: [] }>()
   display: inline-flex;
   min-width: 104px;
   height: 40px;
+  position: relative;
   align-items: center;
   justify-content: center;
   gap: 8px;
@@ -116,5 +118,45 @@ const emit = defineEmits<{ click: [] }>()
 .toolbar-control--active .control-detail {
   background: var(--brand);
   color: var(--font-white);
+}
+
+@media (max-width: 480px) {
+  .toolbar-control {
+    width: 40px;
+    min-width: 40px;
+    height: 40px;
+    padding: 0;
+    gap: 0;
+    border-color: transparent;
+    background: transparent;
+  }
+
+  .toolbar-control:hover,
+  .toolbar-control:focus-visible {
+    border-color: transparent;
+    background: var(--bg-hover);
+  }
+
+  .toolbar-control--active {
+    border-color: transparent;
+    background: color-mix(in srgb, var(--brand) 12%, transparent);
+  }
+
+  .control-label,
+  .control-detail {
+    display: none;
+  }
+
+  .control-badge {
+    position: absolute;
+    top: -6px;
+    right: -6px;
+    min-width: 18px;
+    height: 18px;
+    padding: 0 5px;
+    border: 2px solid var(--bg-default);
+    border-radius: 999px;
+    font-size: 10px;
+  }
 }
 </style>

--- a/app/components/search-bar.vue
+++ b/app/components/search-bar.vue
@@ -10,6 +10,8 @@
         'focus:shadow-[0_4px_16px_rgba(139,92,246,0.2)]',
       ]"
       placeholder="搜尋表情包"
+      @focus="emit('focus')"
+      @blur="emit('blur')"
       @input="handleInput"
     >
     <div class="py-0 absolute right-3 h-full flex justify-center items-center gap-2">
@@ -42,7 +44,7 @@ const props = defineProps<{
 }>()
 
 const search = ref('')
-const emit = defineEmits(['update:search', 'update:semantic'])
+const emit = defineEmits(['update:search', 'update:semantic', 'focus', 'blur'])
 const { showToast } = useAppToast()
 
 const handleInput = () => {

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -2,21 +2,22 @@
   <div class="flex flex-col w-screen h-full bg-[--bg-default]">
     <Header class="outline outline-offset-0 outline-[--outline] outline-2" />
     <div class="p-10">
-      <search-bar
-        class="mb-5"
-        :semantic-enabled="isSemantic"
-        @update:search="handleSearch"
-        @update:semantic="isSemantic = $event"
-      />
-      <div class="flex w-full justify-end gap-2">
-        <button-sort
-          class="mb-5"
-          @update:sort="handleSort"
+      <div
+        class="search-toolbar"
+        :class="{ 'search-toolbar--focused': isSearchFocused }"
+      >
+        <search-bar
+          class="search-toolbar__search"
+          :semantic-enabled="isSemantic"
+          @update:search="handleSearch"
+          @update:semantic="isSemantic = $event"
+          @focus="isSearchFocused = true"
+          @blur="isSearchFocused = false"
         />
-        <button-filter
-          class="mb-5"
-          @update:filter="handleFilter"
-        />
+        <div class="search-toolbar__controls">
+          <button-sort @update:sort="handleSort" />
+          <button-filter @update:filter="handleFilter" />
+        </div>
       </div>
       <main-view-panel
         class="mt-5"
@@ -41,6 +42,7 @@ const searchQuery = ref<string>('')
 const sortOrder = ref<string>('id')
 const filterQuery = ref<FilterOptions>(createEmptyFilters())
 const isSemantic = ref(false)
+const isSearchFocused = ref(false)
 
 // 處理搜尋更新
 const handleSearch = (newSearch: string) => {
@@ -56,3 +58,60 @@ const handleSort = (newSort: string) => {
   sortOrder.value = newSort
 }
 </script>
+
+<style scoped>
+.search-toolbar__controls {
+  display: flex;
+  width: 100%;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-bottom: 20px;
+}
+
+@media (max-width: 480px) {
+  .search-toolbar {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .search-toolbar__search {
+    min-width: 0;
+    flex: 1 1 auto;
+  }
+
+  .search-toolbar__controls {
+    width: 84px;
+    max-width: 84px;
+    flex: 0 0 84px;
+    gap: 4px;
+    margin-bottom: 0;
+    overflow: hidden;
+    opacity: 1;
+    transform: translateX(0);
+    transition: max-width 220ms ease, flex-basis 220ms ease, opacity 160ms ease, transform 220ms ease, gap 220ms ease, visibility 0s linear 0s;
+    visibility: visible;
+  }
+
+  .search-toolbar--focused .search-toolbar__search {
+    flex-basis: 100%;
+  }
+
+  .search-toolbar--focused .search-toolbar__controls {
+    width: 0;
+    max-width: 0;
+    flex-basis: 0;
+    gap: 0;
+    opacity: 0;
+    transform: translateX(8px);
+    transition: max-width 220ms ease, flex-basis 220ms ease, opacity 160ms ease, transform 220ms ease, gap 220ms ease, visibility 0s linear 220ms;
+    visibility: hidden;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .search-toolbar__controls {
+    transition: none;
+  }
+}
+</style>

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -66,6 +66,7 @@ const handleSort = (newSort: string) => {
   justify-content: flex-end;
   gap: 8px;
   margin-bottom: 20px;
+  padding-top: 20px;
 }
 
 @media (max-width: 480px) {
@@ -78,6 +79,7 @@ const handleSort = (newSort: string) => {
   .search-toolbar__search {
     min-width: 0;
     flex: 1 1 auto;
+    margin-bottom: 0;
   }
 
   .search-toolbar__controls {
@@ -86,7 +88,7 @@ const handleSort = (newSort: string) => {
     flex: 0 0 84px;
     gap: 4px;
     margin-bottom: 0;
-    overflow: hidden;
+    overflow: visible;
     opacity: 1;
     transform: translateX(0);
     transition: max-width 220ms ease, flex-basis 220ms ease, opacity 160ms ease, transform 220ms ease, gap 220ms ease, visibility 0s linear 0s;
@@ -103,6 +105,7 @@ const handleSort = (newSort: string) => {
     flex-basis: 0;
     gap: 0;
     opacity: 0;
+    overflow: hidden;
     transform: translateX(8px);
     transition: max-width 220ms ease, flex-basis 220ms ease, opacity 160ms ease, transform 220ms ease, gap 220ms ease, visibility 0s linear 220ms;
     visibility: hidden;

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -88,7 +88,9 @@ const handleSort = (newSort: string) => {
     flex: 0 0 84px;
     gap: 4px;
     margin-bottom: 0;
+    padding-top: 0;
     overflow: visible;
+    align-items: center;
     opacity: 1;
     transform: translateX(0);
     transition: max-width 220ms ease, flex-basis 220ms ease, opacity 160ms ease, transform 220ms ease, gap 220ms ease, visibility 0s linear 0s;


### PR DESCRIPTION
## Summary
- 修正 iPhone 窄版面下亮暗色按鈕換行問題
- 手機版排序／篩選改為靠右的 icon controls
- 搜尋框 focus 時隱藏 controls 並以動畫展開

## Verification
- `bun run lint`
- `bun run build`
- `git diff --check`

Related: #18